### PR TITLE
feat: added new feature: useImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 - [Package contents](#package-contents)
   - [Wrappers](#wrappers)
     - [withAuthGuard](#withauthguard)
+  - [Hooks](#hooks)
+    - [useImage](#useimage)
+    - [useCookie](#usecookie)
   - [Utils](#utils)
     - [login](#login)
     - [isLocalCredentials](#islocalcredentials)
@@ -66,6 +69,21 @@ const Fallback401 = () => <div data-testid="auth-error-401">401</div>;
 // InternalErrorComponent
 const Fallback500 = () => <div data-testid="auth-error-500">500</div>;
 ```
+
+## Hooks
+
+### useImage
+
+Provides an easy way to convert an image file into `base64` string. Returns the data url. The API allows you to pass a configuration object where you can modify the request.
+
+```jsx
+function Component() {
+  const imageUrl = useImage('path_to_image');
+  return <img src={imageUrl} />;
+}
+```
+
+### useCookie
 
 ## Utils
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useImage } from './useImage/useImage';

--- a/src/hooks/useImage/useImage.test.tsx
+++ b/src/hooks/useImage/useImage.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import React from 'react';
+import useImage from './useImage';
+
+jest.mock('axios'); // Mock axios module
+
+describe('useImage', () => {
+  const url = 'https://example.com/image.jpg';
+  let getSpy: jest.SpyInstance;
+
+  const TestComponent = (): JSX.Element => {
+    const imageUrl = useImage(url);
+    return <div data-testid="image">{imageUrl}</div>;
+  };
+
+  beforeEach(() => {
+    getSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({ data: createTestBlob() }));
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+  });
+
+  it('should fetch and return the data URL for the provided image URL', async () => {
+    render(<TestComponent />);
+
+    const node = await screen.findByTestId('image');
+
+    await waitFor(() => {
+      expect(node.textContent?.length).not.toEqual(0);
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(axios.get).toHaveBeenCalledWith(url, { responseType: 'blob', signal: new AbortController().signal });
+  });
+});
+
+function createTestBlob(): Blob {
+  const dataUrl = 'data:text/plain;base64,c2FtcGxlX2RhdGFfdGV4dA==';
+  const data = Buffer.from(dataUrl.split(',')[1], 'base64');
+  return new Blob([data], { type: 'text/plain' });
+}

--- a/src/hooks/useImage/useImage.tsx
+++ b/src/hooks/useImage/useImage.tsx
@@ -1,0 +1,29 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { useEffect, useMemo, useState } from 'react';
+
+function useImage(url: string, config?: UseImageConfig): string {
+  const [dataUrl, setDataUrl] = useState<string>('');
+  const client = useMemo(() => config?.httpClient || axios, [config?.httpClient]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    client.get(url, { ...config, responseType: 'blob', signal: controller.signal }).then(({ data }) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setDataUrl(typeof reader.result === 'string' ? reader.result : '');
+      };
+      reader.readAsDataURL(data);
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return dataUrl;
+}
+
+export default useImage;
+
+export type UseImageConfig = Omit<AxiosRequestConfig, 'responseType' | 'signal'> & { httpClient?: AxiosInstance };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 // export everything here..
 export * from './hoc';
+export * from './hooks';
 export * from './utils';


### PR DESCRIPTION
It should be used to convert image files into `base64` strings. Most practical use is when you request a protected endpoint, because unlike the `<img />` tag, it can send authorization info, using the `config` object

Finished #30