### PR TITLE
fix: changed useFetch config in user provider

### DIFF
--- a/src/utils/createUserProvider/createUserProvider.test.tsx
+++ b/src/utils/createUserProvider/createUserProvider.test.tsx
@@ -23,11 +23,11 @@ describe('createUserProvider', () => {
     const userData: User = { id: 1, email: 'test@test.com' };
 
     beforeEach(() => {
-      const mockFetch: jest.Mock<Promise<User>> = jest.fn();
+      const mockFetch: jest.Mock<User> = jest.fn();
       factory = createUserProvider<User>({
         ...providerOptions,
         mode: 'fetch',
-        useFetch: mockFetch.mockImplementation(() => Promise.resolve(userData)),
+        useFetch: mockFetch.mockImplementation(() => userData),
       });
     });
 


### PR DESCRIPTION
The intended use of the `config.useFetch` was (as the name indicates) to be used as a hook. In order to achieve that we had to remove the ability to return promises from the function