### PR TITLE
fix: fixed reload issues in user provider

### DIFF
--- a/src/utils/createUserProvider/utils.ts
+++ b/src/utils/createUserProvider/utils.ts
@@ -41,10 +41,14 @@ export function useInitialUser<TUser extends DefaultUser = DefaultUser>(
   const [user, setUser] = useState<TUser | null>(profile);
 
   useEffect(() => {
-    if (config.mode === 'fetch') return;
+    if (config.mode === 'fetch') {
+      setUser(profile);
+      return;
+    }
+
     const storage = config.storage || 'cookie';
     setUser(parseInitialUser(storage === 'cookie' ? cookies.get(config.key) : window[storage].getItem(config.key)));
-  }, dependencies);
+  }, [profile, ...dependencies]);
 
   return [user, setUser];
 }


### PR DESCRIPTION
Fixed a bug where when the user reloads the page, the useProfile hook runs only once and does not update the user state, therefore showing logged out as the user state is null